### PR TITLE
Fixes crashes when calling `select`.

### DIFF
--- a/DOFavoriteButton/DOFavoriteButton.swift
+++ b/DOFavoriteButton/DOFavoriteButton.swift
@@ -364,7 +364,7 @@ public class DOFavoriteButton: UIButton {
     }
 
     public func select() {
-        select(true)
+        select(animate: true)
     }
     
     public func select(animate animate: Bool) {


### PR DESCRIPTION
Fixes #25.

Cause: the original implementation of `select` is calling a method defined in `UIResponder` not our animation method.